### PR TITLE
Update to Ruby3 and octokit 9.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ruby:2.7-alpine
+FROM ruby:3.2-alpine
 RUN apk add --no-cache git && \
-    gem install -N octokit -v 4.18.0
+    gem install -N octokit -v 9.1.0
 COPY main.rb /
 
 ENTRYPOINT ["ruby", "/main.rb"]


### PR DESCRIPTION
Currently building gems with ruby 2.7 fails on installing `octokit -v 4.18.0`. This PR is to bring it to ruby 3.2 and `octokit 9.1.0`